### PR TITLE
Remove chown of secrets and configmaps

### DIFF
--- a/assets/runtime/functions
+++ b/assets/runtime/functions
@@ -151,9 +151,4 @@ initialize_system() {
   initialize_datadir
   gitlab_configure_secrets
   generate_ssh_host_keys
-
-  # chown externally mounted config files
-  chown -R git: \
-    ${GITLAB_INSTALL_DIR?}/config/ \
-    ${GITLAB_SHELL_INSTALL_DIR?}/config.yml
 }


### PR DESCRIPTION
See kubernetes/kubernetes#58720
The chown breaks the gitlab startup in k8s 1.9 and is not necessary.